### PR TITLE
Improvements Japanese

### DIFF
--- a/Docs/Manual/JP/Shortcut_keys.xml
+++ b/Docs/Manual/JP/Shortcut_keys.xml
@@ -879,7 +879,7 @@
   </table>
 
   <table>
-    <title>ズーム</title>
+    <title>拡大/縮小</title>
 
     <tgroup cols="2">
       <thead>
@@ -898,7 +898,7 @@
               <keycap>+</keycap>
             </keycombo></entry>
 
-          <entry>フォントサイズを拡大</entry>
+          <entry>フォントの表示倍率を拡大</entry>
         </row>
 
         <row>
@@ -908,7 +908,7 @@
               <keycap>-</keycap>
             </keycombo></entry>
 
-          <entry>フォントサイズを縮小</entry>
+          <entry>フォントの表示倍率を縮小</entry>
         </row>
 
         <row>
@@ -918,7 +918,7 @@
               <keycap>*</keycap>
             </keycombo></entry>
 
-          <entry>フォントサイズを元に戻す</entry>
+          <entry>フォントの表示倍率を標準に戻す</entry>
         </row>
 
         <row>
@@ -928,7 +928,7 @@
               <mousebutton>マウスホイールを上へ</mousebutton>
             </keycombo></entry>
 
-          <entry>フォントサイズを拡大</entry>
+          <entry>フォントの表示倍率を拡大</entry>
         </row>
 
         <row>
@@ -938,7 +938,7 @@
               <mousebutton>マウスホイールを下へ</mousebutton>
             </keycombo></entry>
 
-          <entry>フォントサイズを縮小</entry>
+          <entry>フォントの表示倍率を縮小</entry>
         </row>
       </tbody>
     </tgroup>

--- a/Translations/WinMerge/Japanese.po
+++ b/Translations/WinMerge/Japanese.po
@@ -164,21 +164,21 @@ msgid "Flip H&orizontally"
 msgstr "左右反転(&O)"
 
 msgid "&Zoom"
-msgstr "拡大(&Z)"
+msgstr "拡大/縮小(&Z)"
 
 #, c-format
 msgid "25%"
 msgstr "25%"
 
 msgid "Zoom &In\tCtrl++"
-msgstr "ズームイン(&I)\tCtrl++"
+msgstr "拡大(&I)\tCtrl++"
 
 msgid "Zoom &Out\tCtrl+-"
-msgstr "ズームアウト(&O)\tCtrl+-"
+msgstr "縮小(&O)\tCtrl+-"
 
 #. Zoom to normal
 msgid "&Normal\tCtrl+*"
-msgstr "元に戻す(&N)\tCtrl+*"
+msgstr "標準に戻す(&N)\tCtrl+*"
 
 msgid "&Overlay"
 msgstr "重ね合わせ(&O)"


### PR DESCRIPTION
こんにちは。

「メニュ」>「表示」>「拡大」コマンドにおいて、「拡大」「ズーム」の語句が混在しているので、整理・統一しました。

- コマンド名を「拡大」→「拡大/縮小」に
- 「ズームイン」/「ズームアウト」→「拡大」/「縮小」に
- 拡大における「元に戻す」が操作を戻すのと同じ表現で混同するのと、「元」が意味するところが曖昧なので「標準に戻す」に
- マニュアルの該当箇所についても修正

よろしくお願いします。